### PR TITLE
feat: render see also links

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -59,8 +59,9 @@ quartodoc:
     - title: geom
       desc: |
         Base class of all geoms
+      package: plotnine.geoms.geom
       contents:
-        - geoms.geom.geom
+        - geom
     - title: geoms
       desc: |
         Geometric objects (geoms) are responsible for the visual representation

--- a/_renderer.py
+++ b/_renderer.py
@@ -76,7 +76,7 @@ class Renderer(MdRenderer):
             else:
                 result.append(str_links)
 
-        return "*\n".join(result)
+        return "* " + "\n* ".join(result)
 
     def render_annotation(self, el: dc.Name | dc.Expression | None):
         return super().render_annotation(el)

--- a/_renderer.py
+++ b/_renderer.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import html
 from importlib.resources import files
+from numpydoc.docscrape import NumpyDocString
 from quartodoc import MdRenderer
 from quartodoc.renderers.base import convert_rst_link_to_md
 from quartodoc import layout
+from quartodoc import ast as qast
 from plum import dispatch
 from tabulate import tabulate
 from typing import Union
@@ -54,6 +56,27 @@ class Renderer(MdRenderer):
             return DOCSTRING_TMPL.format(rendered=converted, examples=example)
 
         return converted
+
+    @dispatch
+    def render(self, el: qast.DocstringSectionSeeAlso):
+        lines = el.value.split("\n")
+
+        # each entry in result has form: ([('func1', '<directive>), ...], <description>)
+        parsed = NumpyDocString("")._parse_see_also(lines)
+
+        result = []
+        for funcs, description in parsed:
+            links = [f"[{name}](`{name}`)" for name, role in funcs]
+
+            str_links = ", ".join(links)
+
+            if description:
+                str_description = "<br>".join(description)
+                result.append(f"{str_links}: {str_description}")
+            else:
+                result.append(str_links)
+
+        return "*\n".join(result)
 
     def render_annotation(self, el: dc.Name | dc.Expression | None):
         return super().render_annotation(el)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ griffe @ git+https://github.com/machow/griffe.git@fix-numpy-block-linebreaks
 quartodoc @ git+https://github.com/machow/quartodoc.git@dev-plotnine
 plotnine @ git+https://github.com/machow/plotnine.git@docs-quartodoc
 pyyaml
+numpydoc


### PR DESCRIPTION
Addresses #10. 

Note that this does not render links for `aes()`, since it is able to refer to omit the module name in sphinx (eg `after_stat`, rather than `plotnine.after_stat`). I don't think there's an easy way for us to resolve this, without including a construct like the `.. currentmodule::` directive in the filter.

<img width="1180" alt="image" src="https://github.com/machow/plotnine-docs-demo/assets/2574498/6ac6a59f-7a0c-4525-ae9d-36b090543b43">
